### PR TITLE
Fix incorrect parameter to check change

### DIFF
--- a/src/main/kotlin/net/cafesalam/profilerutil/benchmark/BenchmarkChecker.kt
+++ b/src/main/kotlin/net/cafesalam/profilerutil/benchmark/BenchmarkChecker.kt
@@ -17,7 +17,7 @@ object BenchmarkChecker {
 
       val stepDelta = StepFit.stepFit(runsBefore, runsAfter)
       if (stepDelta.absoluteValue >= threshold) {
-        if (threshold > 0) BenchmarkStep.IMPROVEMENT
+        if (stepDelta > 0) BenchmarkStep.IMPROVEMENT
         else BenchmarkStep.REGRESSION
       } else {
         BenchmarkStep.NO_CHANGE


### PR DESCRIPTION
The wrong variable was being used to check if a detected change was a
regression or an improvement. Consequently, almost all changes were
returned as improvements.
